### PR TITLE
fix(): check if data is not null before reference 

### DIFF
--- a/dist/user-cookie-provider.js
+++ b/dist/user-cookie-provider.js
@@ -244,7 +244,7 @@ var xDomainCookie = __webpack_require__(1);
             } catch (e) {
             }
 
-            if (typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
+            if (!data || typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
             if (!('namespace' in data) || data.namespace !== _namespace) return; //wrong namespace for msg
             if (!('msg_type' in data)) return; //data is not a xdomainc-cookie payload
 

--- a/dist/xdomain_cookie.html
+++ b/dist/xdomain_cookie.html
@@ -140,7 +140,7 @@
             } catch (e) {
             }
 
-            if (typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
+            if (!data || typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
             if (!('msg_type' in data) || data.msg_type !== 'xdsc_write') return; //data is not a xdomainc-cookie payload
             if (!('namespace' in data) || data.namespace !== _namespace) return; //wrong namespace for msg
 

--- a/src/xdomain_cookie.html
+++ b/src/xdomain_cookie.html
@@ -140,7 +140,7 @@
             } catch (e) {
             }
 
-            if (typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
+            if (!data || typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
             if (!('msg_type' in data) || data.msg_type !== 'xdsc_write') return; //data is not a xdomainc-cookie payload
             if (!('namespace' in data) || data.namespace !== _namespace) return; //wrong namespace for msg
 

--- a/src/xdomain_cookie.js
+++ b/src/xdomain_cookie.js
@@ -80,7 +80,7 @@
             } catch (e) {
             }
 
-            if (typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
+            if (!data || typeof data !== 'object' || (data instanceof Array)) return; //data is not a non-array object
             if (!('namespace' in data) || data.namespace !== _namespace) return; //wrong namespace for msg
             if (!('msg_type' in data)) return; //data is not a xdomainc-cookie payload
 


### PR DESCRIPTION
In case JSON parsing error, data object stays null
in this case, we getting error while trying to reference 'namespace' in data